### PR TITLE
feat: initial implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,44 @@
+language: node_js
+cache: npm
+stages:
+  - check
+  - test
+  - cov
+
+node_js:
+  - '10'
+  - '12'
+
+os:
+  - linux
+  - osx
+  - windows
+
+script: npx nyc -s npm run test:node -- --bail
+after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov
+
+jobs:
+  include:
+    - stage: check
+      script:
+        - npx aegir build --bundlesize
+        # Remove pull libs once ping is async
+        - npx aegir dep-check
+        - npm run lint
+
+    - stage: test
+      name: chrome
+      addons:
+        chrome: stable
+      script:
+        - npx aegir test -t browser -t webworker
+
+    - stage: test
+      name: firefox
+      addons:
+        firefox: latest
+      script:
+        - npx aegir test -t browser -t webworker -- --browsers FirefoxHeadless
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ jobs:
   include:
     - stage: check
       script:
-        - npx aegir build --bundlesize
-        # Remove pull libs once ping is async
         - npx aegir dep-check
         - npm run lint
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# js-libp2p Pubsub Peer Discovery
+
+[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)
+[![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
+[![](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
+[![](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg)](https://discuss.libp2p.io)
+
+> A js-libp2p module that uses pubsub for mdns like peer discovery
+
+## Lead Maintainer
+
+[Jacob Heun](https://github.com/jacobheun).
+
+## Design
+
+This module takes a similar approach to [MulticastDNS (MDNS)](https://github.com/libp2p/specs/blob/master/discovery/mdns.md) queries, except it leverages pubsub to "query" peers on the pubsub topic. A `Query` is performed by publishing a unique Query ID, along with your peers information (Peer ID, PublicKey, Multiaddrs). Each peer that receives the Query will submit a `QueryResponse`, consisting of their peer information and the Query ID being responded to.
+
+### Flow
+- When the discovery module is started by libp2p it subscribes to the discovery pubsub topic
+- Once subscribed, the peer will "query" the network by publishing a `Query`
+- The `Query` will also include your peers `QueryResponse`, so that other nodes can learn about you without needing to poll
+- Whenever another pubsub discovery peer joins the pubsub mesh, it will post its `Query`
+
+### Security Considerations
+It is worth noting that this module does not include any message signing for queries. The reason for this is that libp2p-pubsub supports message signing and enables it by default, which means the message you received has been verified to be from the originator, so we can trust that the peer information we have received is indeed from the peer who owns it. This doesn't mean the peer can't falsify its own records, but this module isn't currently concerned with that scenario.
+
+## Usage
+
+### Requirements
+
+This module *MUST* be used on a libp2p node that is running [Pubsub](https://github.com/libp2p/js-libp2p-pubsub). If Pubsub does not exist, or is not running, this module will not work.
+
+## Contribute
+
+Feel free to join in. All welcome. Open an [issue](https://github.com/libp2p/js-libp2p-pubsub-peer-discovery/issues)!
+
+This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
+
+[![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/contributing.md)
+
+## License
+
+MIT - Protocol Labs 2019

--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/c
 
 ## License
 
-MIT - Protocol Labs 2019
+MIT - Protocol Labs 2020

--- a/package.json
+++ b/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "libp2p-pubsub-peer-discovery",
+  "version": "0.0.0",
+  "description": "A libp2p module that uses pubsub for mdns like peer discovery",
+  "main": "src/index.js",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/libp2p/js-libp2p.git"
+  },
+  "keywords": [
+    "libp2p",
+    "peer",
+    "discovery",
+    "pubsub"
+  ],
+  "bugs": {
+    "url": "https://github.com/libp2p/js-libp2p/issues"
+  },
+  "homepage": "https://libp2p.io",
+  "license": "MIT",
+  "engines": {
+    "node": ">=10.0.0",
+    "npm": ">=6.0.0"
+  },
+  "scripts": {
+    "lint": "aegir lint",
+    "build": "aegir build",
+    "test": "aegir test",
+    "test:node": "aegir test -t node",
+    "test:browser": "aegir test -t browser",
+    "release": "aegir release",
+    "release-minor": "aegir release --type minor",
+    "release-major": "aegir release --type major",
+    "coverage": "nyc --reporter=text --reporter=lcov npm test"
+  },
+  "devDependencies": {
+    "aegir": "^21.4.5",
+    "chai": "^4.2.0",
+    "dirty-chai": "^2.0.1",
+    "libp2p-interfaces": "^0.2.7",
+    "multiaddr": "^7.4.3",
+    "p-defer": "^3.0.0",
+    "peer-id": "^0.13.11",
+    "peer-info": "^0.17.5"
+  },
+  "dependencies": {
+    "debug": "^4.1.1",
+    "emittery": "^0.6.0",
+    "libp2p-crypto": "^0.17.5",
+    "protons": "^1.0.2"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "libp2p-pubsub-peer-discovery",
   "version": "0.0.0",
   "description": "A libp2p module that uses pubsub for mdns like peer discovery",
+  "leadMaintainer": "Jacob Heun <jacobheun@gmail.com>",
   "main": "src/index.js",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "multiaddr": "^7.4.3",
     "p-defer": "^3.0.0",
     "peer-id": "^0.13.11",
-    "peer-info": "^0.17.5"
+    "peer-info": "^0.17.5",
+    "sinon": "^9.0.1"
   },
   "dependencies": {
     "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -42,16 +42,16 @@
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "libp2p-interfaces": "^0.2.7",
-    "multiaddr": "^7.4.3",
     "p-defer": "^3.0.0",
-    "peer-id": "^0.13.11",
-    "peer-info": "^0.17.5",
     "sinon": "^9.0.1"
   },
   "dependencies": {
     "debug": "^4.1.1",
     "emittery": "^0.6.0",
     "libp2p-crypto": "^0.17.5",
+    "multiaddr": "^7.4.3",
+    "peer-id": "^0.13.11",
+    "peer-info": "^0.17.5",
     "protons": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/libp2p/js-libp2p.git"
+    "url": "https://github.com/libp2p/js-libp2p-pubsub-peer-discovery.git"
   },
   "keywords": [
     "libp2p",
@@ -18,7 +18,7 @@
     "pubsub"
   ],
   "bugs": {
-    "url": "https://github.com/libp2p/js-libp2p/issues"
+    "url": "https://github.com/libp2p/js-libp2p-pubsub-peer-discovery/issues"
   },
   "homepage": "https://libp2p.io",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ class PubsubPeerDiscovery extends Emittery {
     this.libp2p = libp2p
     this.delay = delay
     this._timeout = null
+    this.removeListener = this.off.bind(this)
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ class PubsubPeerDiscovery extends Emittery {
   /**
    *
    * @param {Libp2p} param0.libp2p Our libp2p node
-   * @param {Number} param0.delay How long to wait (ms) after startup before publishing our Query. Default: 1000ms
+   * @param {Number} [param0.delay] How long to wait (ms) after startup before publishing our Query. Default: 1000ms
    */
   constructor ({ libp2p, delay = 1000 }) {
     super()

--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,8 @@ class PubsubPeerDiscovery extends Emittery {
    * after `this.delay` milliseconds
    */
   start () {
+    if (this._timeout) return
+
     // Subscribe to pubsub
     this.libp2p.pubsub.subscribe(TOPIC, (msg) => this._onMessage(msg))
     // Perform a delayed publish to give pubsub time to do its thing
@@ -112,6 +114,7 @@ class PubsubPeerDiscovery extends Emittery {
       const peerInfo = new PeerInfo(peerId)
       query.queryResponse.addrs.forEach(buffer => peerInfo.multiaddrs.add(multiaddr(buffer)))
       this.emit('peer', peerInfo)
+      log('discovered peer', peerInfo.id)
       return true
     } catch (err) {
       log.error(err)
@@ -132,6 +135,7 @@ class PubsubPeerDiscovery extends Emittery {
       const peerInfo = new PeerInfo(peerId)
       queryResponse.addrs.forEach(buffer => peerInfo.multiaddrs.add(multiaddr(buffer)))
       this.emit('peer', peerInfo)
+      log('discovered peer', peerInfo.id)
     } catch (err) {
       log.error(err)
     }

--- a/src/index.js
+++ b/src/index.js
@@ -140,3 +140,4 @@ class PubsubPeerDiscovery extends Emittery {
 
 module.exports = PubsubPeerDiscovery
 module.exports.TOPIC = TOPIC
+module.exports.tag = 'PubsubPeerDiscovery'

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,140 @@
+'use strict'
+
+const Emittery = require('emittery')
+const debug = require('debug')
+
+const PeerId = require('peer-id')
+const PeerInfo = require('peer-info')
+const randomBytes = require('libp2p-crypto/src/random-bytes')
+const multiaddr = require('multiaddr')
+
+const PB = require('./query')
+
+const log = debug('libp2p:discovery:pubsub')
+log.error = debug('libp2p:discovery:pubsub:error')
+const TOPIC = '_peer-discovery._p2p._pubsub'
+
+/**
+ * @typedef Message
+ * @property {string} from
+ * @property {Buffer} data
+ * @property {Buffer} seqno
+ * @property {Array<string>} topicIDs
+ * @property {Buffer} signature
+ * @property {key} Buffer
+ */
+
+/**
+  * A Peer Discovery Service that leverages libp2p Pubsub to find peers.
+  */
+class PubsubPeerDiscovery extends Emittery {
+  // TODO: The default delay may be too high here.
+  // By the time the service is started, libp2p will be listening on all transports (including relays)
+  // and pubsub will be started. The delay is to give pubsub time to prime. Ideally, we might do an
+  // initial check to wait for other subscribers before making our startup Query. However, in the
+  // unlikely event that we are the first peer, we would be waiting unncessarily, as the next peer would
+  // query and result in our discovery of them
+  /**
+   *
+   * @param {Libp2p} param0.libp2p Our libp2p node
+   * @param {Number} param0.delay How long to wait (ms) after startup before publishing our Query
+   */
+  constructor ({ libp2p, delay = 5000 }) {
+    super()
+    this.libp2p = libp2p
+    this.delay = delay
+    this._timeout = null
+  }
+
+  /**
+   * Subscribes to the discovery topic on `libp2p.pubsub` and peforms a query
+   * after `this.delay` milliseconds
+   */
+  start () {
+    // Subscribe to pubsub
+    this.libp2p.pubsub.subscribe(TOPIC, (msg) => this._onMessage(msg))
+    // Perform a delayed publish to give pubsub time to do its thing
+    this._timeout = setTimeout(() => {
+      this._query()
+    }, this.delay)
+  }
+
+  /**
+   * Unsubscribes from the discovery topic
+   * @async
+   */
+  stop () {
+    clearTimeout(this._timeout)
+    this._timeout = null
+    this.libp2p.pubsub.unsubscribe(TOPIC)
+  }
+
+  /**
+   * Performs a Query via Pubsub publish
+   */
+  _query () {
+    const id = randomBytes(32)
+    const query = {
+      id,
+      queryResponse: {
+        queryID: id,
+        publicKey: this.peerInfo.id.publicKey.bytes,
+        addrs: this.libp2p.peerInfo.multiaddrs.map(ma => ma.buffer)
+      }
+    }
+    const encodedQuery = PB.Query.encode(query)
+    this.libp2p.pubsub.publish(TOPIC, encodedQuery)
+  }
+
+  /**
+   * Handles incoming pubsub messages for our discovery topic
+   * @async
+   * @param {Message} message
+   */
+  async _onMessage (message) {
+    if (await this._handleQuery(message.data)) return
+
+    this._handleQueryResponse(message.data)
+  }
+
+  /**
+   * Attempts to decode a QueryResponse from the given data. Any errors will be logged and ignored.
+   * @private
+   * @async
+   * @param {Buffer} data The Pubsub message data to decode
+   */
+  async _handleQuery (data) {
+    try {
+      const query = PB.Query.decode(data)
+      const peerId = await PeerId.createFromPubKey(query.queryResponse.publicKey)
+      const peerInfo = new PeerInfo(peerId)
+      query.queryResponse.addrs.forEach(buffer => peerInfo.multiaddrs.add(multiaddr(buffer)))
+      this.emit('peer', peerInfo)
+      return true
+    } catch (err) {
+      log.error(err)
+      return false
+    }
+  }
+
+  /**
+   * Attempts to decode a QueryResponse from the given data. Any errors will be logged and ignored.
+   * @private
+   * @async
+   * @param {Buffer} data The Pubsub message data to decode
+   */
+  async _handleQueryResponse (data) {
+    try {
+      const queryResponse = PB.QueryResponse.decode(data)
+      const peerId = await PeerId.createFromPubKey(queryResponse.publicKey)
+      const peerInfo = new PeerInfo(peerId)
+      queryResponse.addrs.forEach(buffer => peerInfo.multiaddrs.add(multiaddr(buffer)))
+      this.emit('peer', peerInfo)
+    } catch (err) {
+      log.error(err)
+    }
+  }
+}
+
+module.exports = PubsubPeerDiscovery
+module.exports.TOPIC = TOPIC

--- a/src/index.js
+++ b/src/index.js
@@ -78,8 +78,8 @@ class PubsubPeerDiscovery extends Emittery {
       id,
       queryResponse: {
         queryID: id,
-        publicKey: this.peerInfo.id.publicKey.bytes,
-        addrs: this.libp2p.peerInfo.multiaddrs.map(ma => ma.buffer)
+        publicKey: this.libp2p.peerInfo.id.pubKey.bytes,
+        addrs: this.libp2p.peerInfo.multiaddrs.toArray().map(ma => ma.buffer)
       }
     }
     const encodedQuery = PB.Query.encode(query)
@@ -107,6 +107,8 @@ class PubsubPeerDiscovery extends Emittery {
     try {
       const query = PB.Query.decode(data)
       const peerId = await PeerId.createFromPubKey(query.queryResponse.publicKey)
+      // Ignore if we received our own response
+      if (peerId.equals(this.libp2p.peerInfo.id)) return
       const peerInfo = new PeerInfo(peerId)
       query.queryResponse.addrs.forEach(buffer => peerInfo.multiaddrs.add(multiaddr(buffer)))
       this.emit('peer', peerInfo)

--- a/src/index.js
+++ b/src/index.js
@@ -28,18 +28,12 @@ const TOPIC = '_peer-discovery._p2p._pubsub'
   * A Peer Discovery Service that leverages libp2p Pubsub to find peers.
   */
 class PubsubPeerDiscovery extends Emittery {
-  // TODO: The default delay may be too high here.
-  // By the time the service is started, libp2p will be listening on all transports (including relays)
-  // and pubsub will be started. The delay is to give pubsub time to prime. Ideally, we might do an
-  // initial check to wait for other subscribers before making our startup Query. However, in the
-  // unlikely event that we are the first peer, we would be waiting unncessarily, as the next peer would
-  // query and result in our discovery of them
   /**
    *
    * @param {Libp2p} param0.libp2p Our libp2p node
-   * @param {Number} param0.delay How long to wait (ms) after startup before publishing our Query
+   * @param {Number} param0.delay How long to wait (ms) after startup before publishing our Query. Default: 1000ms
    */
-  constructor ({ libp2p, delay = 5000 }) {
+  constructor ({ libp2p, delay = 1000 }) {
     super()
     this.libp2p = libp2p
     this.delay = delay
@@ -64,7 +58,6 @@ class PubsubPeerDiscovery extends Emittery {
 
   /**
    * Unsubscribes from the discovery topic
-   * @async
    */
   stop () {
     clearTimeout(this._timeout)
@@ -74,6 +67,7 @@ class PubsubPeerDiscovery extends Emittery {
 
   /**
    * Performs a Query via Pubsub publish
+   * @private
    */
   _query () {
     const id = randomBytes(32)
@@ -91,6 +85,7 @@ class PubsubPeerDiscovery extends Emittery {
 
   /**
    * Handles incoming pubsub messages for our discovery topic
+   * @private
    * @async
    * @param {Message} message
    */

--- a/src/query.js
+++ b/src/query.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const protons = require('protons')
+const schema = `
+message Query {
+  // id is 32 random bytes
+  required bytes id = 0;
+  required QueryResponse queryResponse = 1;
+}
+
+message QueryResponse {
+  required bytes queryID = 0;
+  required bytes publicKey = 1;
+  repeated bytes addrs = 2;
+}
+`
+
+module.exports = protons(schema)

--- a/test/compliance.spec.js
+++ b/test/compliance.spec.js
@@ -1,0 +1,31 @@
+/* eslint-env mocha */
+'use strict'
+
+const tests = require('libp2p-interfaces/src/peer-discovery/tests')
+const PubsubPeerDiscovery = require('../src')
+
+const PeerID = require('peer-id')
+const PeerInfo = require('peer-info')
+
+describe('compliance tests', () => {
+  tests({
+    async setup () {
+      const peerId = await PeerID.create({ bits: 512 })
+      const peerInfo = new PeerInfo(peerId)
+      await new Promise(resolve => setTimeout(resolve, 10))
+      return new PubsubPeerDiscovery({
+        libp2p: {
+          peerInfo,
+          pubsub: {
+            subscribe: () => {},
+            unsubscribe: () => {},
+            publish: () => {}
+          }
+        }
+      })
+    },
+    async teardown () {
+      await new Promise(resolve => setTimeout(resolve, 10))
+    }
+  })
+})

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -10,7 +10,6 @@ const defer = require('p-defer')
 const PeerID = require('peer-id')
 const PeerInfo = require('peer-info')
 const { randomBytes } = require('libp2p-crypto')
-const multiaddr = require('multiaddr')
 
 const PubsubPeerDiscovery = require('../src')
 const PB = require('../src/query')

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,0 +1,73 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+const { expect } = chai
+const defer = require('p-defer')
+
+const PeerID = require('peer-id')
+const PeerInfo = require('peer-info')
+const { randomBytes } = require('libp2p-crypto')
+const multiaddr = require('multiaddr')
+
+const PubsubPeerDiscovery = require('../src')
+const PB = require('../src/query')
+
+describe('Pubsub Peer Discovery', () => {
+  let mockLibp2p
+  before(async () => {
+    const peerInfo = await PeerInfo.create()
+    mockLibp2p = {
+      peerInfo,
+      pubsub: {
+        subscribe: () => {},
+        publish: () => {},
+        unsubscribe: () => {}
+      }
+    }
+  })
+
+  it('should be able to encode/decode a query', async () => {
+    const discovery = new PubsubPeerDiscovery({ libp2p: mockLibp2p })
+    const id = randomBytes(32)
+    const peerId = await PeerID.create({ bits: 512 })
+    const expectedPeeerInfo = new PeerInfo(peerId)
+    expectedPeeerInfo.multiaddrs.add('/ip4/0.0.0.0/tcp/8080/ws')
+    expectedPeeerInfo.multiaddrs.add('/ip4/0.0.0.0/tcp/8081/ws')
+    const query = {
+      id,
+      queryResponse: {
+        queryID: id,
+        publicKey: peerId.pubKey.bytes,
+        addrs: expectedPeeerInfo.multiaddrs.toArray().map(ma => ma.buffer)
+      }
+    }
+
+    const deferred = defer()
+    const encodedQuery = PB.Query.encode(query)
+    discovery.on('peer', (p) => {
+      deferred.resolve(p)
+    })
+    await discovery._handleQuery(encodedQuery)
+
+    const discoveredPeer = await deferred.promise
+    expect(discoveredPeer.id.equals(expectedPeeerInfo.id)).to.equal(true)
+    expectedPeeerInfo.multiaddrs.forEach(addr => {
+      expect(discoveredPeer.multiaddrs.has(addr)).to.equal(true)
+    })
+  })
+
+  it('should be able to encode/decode a response', async () => {
+    const id = randomBytes(32)
+    const peerId = await PeerID.create({ bits: 512 })
+    const queryResponse = {
+      queryID: id,
+      publicKey: peerId.pubKey.bytes,
+      addrs: [multiaddr('/ip4/0.0.0.0/tcp/8082/ws').buffer, multiaddr('/ip4/0.0.0.0/tcp/8083/ws').buffer]
+    }
+
+    const encodedResponse = PB.QueryResponse.encode(queryResponse)
+    expect(PB.QueryResponse.decode(encodedResponse)).to.eql(queryResponse)
+  })
+})

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -97,7 +97,7 @@ describe('Pubsub Peer Discovery', () => {
     expect(PB.QueryResponse.decode(encodedResponse)).to.eql(queryResponse)
   })
 
-  it('should be able to add and remove peer listeners', async () => {
+  it('should be able to add and remove peer listeners', () => {
     const discovery = new PubsubPeerDiscovery({ libp2p: mockLibp2p })
     const handler = () => {}
     discovery.on('peer', handler)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -96,4 +96,19 @@ describe('Pubsub Peer Discovery', () => {
     const encodedResponse = PB.QueryResponse.encode(queryResponse)
     expect(PB.QueryResponse.decode(encodedResponse)).to.eql(queryResponse)
   })
+
+  it('should be able to add and remove peer listeners', async () => {
+    const discovery = new PubsubPeerDiscovery({ libp2p: mockLibp2p })
+    const handler = () => {}
+    discovery.on('peer', handler)
+    expect(discovery.listenerCount('peer')).to.equal(1)
+    discovery.off('peer', handler)
+    expect(discovery.listenerCount('peer')).to.equal(0)
+
+    // Verify libp2p usage
+    discovery.on('peer', handler)
+    expect(discovery.listenerCount('peer')).to.equal(1)
+    discovery.removeListener('peer', handler)
+    expect(discovery.listenerCount('peer')).to.equal(0)
+  })
 })


### PR DESCRIPTION
This creates a libp2p PeerDiscovery compliant module that leverages Pubsub to discover other peers across the pubsub mesh. The intention is to allow browser peers (and other peers) to connect to discover one another through a mutual pubsub network. 

For browser nodes, this could mean connecting to a relay server on startup. If the relay server is also subscribed to the discovery topic, it would cause all connected peers to discover one another when a peer joins the pubsub topic.

### TODO
- [x] Create a relay server repo and do some integration testing of this (working in tests at https://github.com/jacobheun/js-libp2p-relay-server/pull/1)
- [x] Add some additional tests and cleanup here

### Caveats
Currently libp2p isn't passing itself to the discovery modules when it instantiates them. This should be a trivial addition to libp2p though and is entirely reasonable to do.

### Prior Art
- Inspired by https://github.com/libp2p/js-libp2p-websocket-star/pull/43
- Coupled with a relay server this is a viable replacement for https://github.com/libp2p/js-libp2p-stardust, and https://github.com/libp2p/js-libp2p-websocket-star